### PR TITLE
fix: handle gateways that publish duplicate packets

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -392,9 +392,7 @@ if __name__ == "__main__":
     create_db(conn)
 
     # Start the MQTT client
-    client = paho.Client(
-        paho.CallbackAPIVersion.VERSION2, client_id="ctso-discord-bot-test"
-    )
+    client = paho.Client(paho.CallbackAPIVersion.VERSION2, client_id="meshobserv-7362")
     client.on_message = on_message
     client.on_publish = on_publish
     client.on_connect = on_connect

--- a/mqtt.py
+++ b/mqtt.py
@@ -14,6 +14,7 @@ import yaml
 from cachetools import TTLCache
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from collections import OrderedDict
 from meshtastic import BROADCAST_NUM
 from meshtastic.protobuf import mesh_pb2, mqtt_pb2, portnums_pb2, telemetry_pb2
 
@@ -60,7 +61,7 @@ class DiscordMessage:
         """
         Construct discord message from Meshtastic protobuf.
         """
-        self.mesh_packets = []
+        self.mesh_packets = OrderedDict()
         self.discord_message_id = None
         self.from_id = sender_id(mp)
         self.channel_id = channel_id
@@ -69,7 +70,7 @@ class DiscordMessage:
         self.add_meshpacket(gateway_id, mp)
 
     def add_meshpacket(self, gateway_id: str, mp: mesh_pb2.MeshPacket):
-        self.mesh_packets.append((gateway_id, mp))
+        self.mesh_packets[gateway_id] = mp
 
     def render(self):
         """
@@ -92,7 +93,7 @@ class DiscordMessage:
 
         stats_desc = ""
         index = 1
-        for gateway_id, mp in self.mesh_packets:
+        for gateway_id, mp in self.mesh_packets.items():
             if gateway_id == self.from_id:
                 stats_desc += f"{index}. self-gated\n"
             else:
@@ -189,15 +190,19 @@ def on_message(mosq, obj, msg):
                     discord_msg = DiscordMessage(se.channel_id, se.gateway_id, mp)
                     hist[history_key] = discord_msg
                 else:
-                    # We've seen this message before, update the stored
-                    # message with the latest ServiceEnvelope and MeshPacket
-                    logging.info(f"Existing {portnum_type}: key={history_key}")
-                    discord_msg = hist[history_key]
-                    discord_msg.add_meshpacket(se.gateway_id, mp)
+                    # We've seen this message before, update the existing message
+                    if gateway_node_id not in hist[history_key].mesh_packets:
+                        logging.info(f"Existing {portnum_type}: key={history_key}")
+                        discord_msg = hist[history_key]
+                        discord_msg.add_meshpacket(se.gateway_id, mp)
+                    else:
+                        # We've seen this message from this gateway before, ignore it and bail out
+                        logging.info(
+                            f"Duplicate {portnum_type}: key={history_key}, gateway={gateway_node_id}"
+                        )
+                        return
 
                 discord_msg.publish(channel_config)
-            except Exception as e:
-                logging.info(f"*** Error while processing TEXT_MESSAGE_APP: {str(e)}")
 
         elif mp.decoded.portnum == portnums_pb2.NODEINFO_APP:
             info = mesh_pb2.User()

--- a/mqtt.py
+++ b/mqtt.py
@@ -203,6 +203,8 @@ def on_message(mosq, obj, msg):
                         return
 
                 discord_msg.publish(channel_config)
+            except Exception as e:
+                logging.info(f"*** Error while processing TEXT_MESSAGE_APP: {str(e)}")
 
         elif mp.decoded.portnum == portnums_pb2.NODEINFO_APP:
             info = mesh_pb2.User()
@@ -390,7 +392,9 @@ if __name__ == "__main__":
     create_db(conn)
 
     # Start the MQTT client
-    client = paho.Client(paho.CallbackAPIVersion.VERSION2, client_id="meshobserv-7362")
+    client = paho.Client(
+        paho.CallbackAPIVersion.VERSION2, client_id="ctso-discord-bot-test"
+    )
     client.on_message = on_message
     client.on_publish = on_publish
     client.on_connect = on_connect


### PR DESCRIPTION
I'm assuming the issue we're seeing with messages being seen twice by the same node is likely the node hearing a rebroadcast of itself.

This change adds an `OrderedDict` to deduplicate packets on a per-gateway basis.  The `OrderedDict` will maintain insertion order when iterating, so we should still see the list ordered correctly.

If we see the same message from the same gateway, we will only keep the first.  I think that's probably what we care about, since that is the first opportunity for a node to retransmit.