### PR TITLE
Fix map links, support blocking senders

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,3 +29,5 @@ channels:
 catch_all:
   key: AQ==
   webhook: ${DISCORD_WEBHOOK}
+
+blocked_senders: []

--- a/mqtt.py
+++ b/mqtt.py
@@ -186,6 +186,12 @@ def on_message(mosq, obj, msg):
                     )
                     return
 
+                if from_node_id in CONFIG["blocked_senders"]:
+                    logging.info(
+                        f"Dropping message from blocked sender: {from_node_id}"
+                    )
+                    return
+
                 history_key = discord_message_key(se, mp)
                 if history_key not in hist:
                     logging.info(f"New {portnum_type}: key={history_key}")

--- a/mqtt.py
+++ b/mqtt.py
@@ -65,6 +65,7 @@ class DiscordMessage:
         self.mesh_packets = OrderedDict()
         self.discord_message_id = None
         self.from_id = sender_id(mp)
+        self.from_mac = getattr(mp, "from")
         self.channel_id = channel_id
         self.message_text = mp.decoded.payload.decode("utf-8")
 
@@ -89,7 +90,7 @@ class DiscordMessage:
         }
         if "map_url_prefix" in CONFIG["mqtt"]:
             primary_embed["author"]["url"] = (
-                CONFIG["mqtt"]["map_url_prefix"] + self.from_id
+                CONFIG["mqtt"]["map_url_prefix"] + self.from_mac
             )
 
         stats_desc = ""


### PR DESCRIPTION
- Fixes the map links, those expect the long-form mac address rather than short form
- Add config to block senders based on their "short id".  We can use this to drop messages on the floor from senders that have been posting content that does not match our community expectations, such as hate speech.

Example usage:
```
blocked_senders:
  - "!ffffffff"
```